### PR TITLE
rw_builder/mod.rs has incorrect `RwLock` guard usage

### DIFF
--- a/src/hnsw/rw_builder/mod.rs
+++ b/src/hnsw/rw_builder/mod.rs
@@ -86,8 +86,8 @@ where
     }
 
     pub fn write(self: &Self, index_file: impl Write + Seek, elements_file: impl Write, compress: bool) -> Result<()> {
-        // prevent any writes from happen while saving to disk
-        let _ = self.write_lock.write();
+        // prevent any writes from happening while saving to disk
+        let _guard = self.write_lock.write();
 
         let elements = self.elements.read();
         let (ref current_layer, ref layers) = *self.layers.read();
@@ -125,7 +125,7 @@ where
         }
 
         // signal that writes will happen
-        let _ = self.write_lock.read();
+        let _guard = self.write_lock.read();
 
         let (mut inserted, remaining) = {
             // write locks are needed to append elements and potentially append a new layer


### PR DESCRIPTION
A lock guard needs to be assigned to a binding that's not `_` because doing otherwise creates a guard that's dropped immediately, releasing the lock.  In other words:
```rust
let _ = my_lock.write().unlock();
```
is equivalent to
```rust
my_lock.write().unwrap();
```

I noticed this purely by accident while exploring this repo a bit, after seeing it linked from https://0x65.dev/blog/2019-12-06/building-a-search-engine-from-scratch.html